### PR TITLE
Add Bootstrap 4 pagination support

### DIFF
--- a/lib/kerosene/html.ex
+++ b/lib/kerosene/html.ex
@@ -2,10 +2,10 @@ defmodule Kerosene.HTML do
   use Phoenix.HTML
 
   @default [theme: :bootstrap, window: 5, next: "Next", previous: "Previous", first: true, last: true]
-  @themes [:bootstrap, :foundation, :semantic]
+  @themes [:bootstrap, :bootstrap4, :foundation, :semantic]
 
   @moduledoc """
-  Html helpers to render the pagination links and more, 
+  Html helpers to render the pagination links and more,
   import the `Kerosene.HTML` in your view module.
 
       defmodule MyApp.PostView do
@@ -73,17 +73,14 @@ defmodule Kerosene.HTML do
       |> Enum.map(fn {label, page} -> {label, page, build_url(conn, Keyword.merge(paginator.params, [page: page]))} end)
   end
 
-  defp render_page_list(page_list, paginator, [theme: :bootstrap, path: _path, params: _params, opts: _opts]) do
-    Kerosene.HTML.Boostrap.generate_links(page_list, paginator)
-  end
-  defp render_page_list(page_list, paginator, [theme: :foundation, path: _path, params: _params, opts: _opts]) do
-    Kerosene.HTML.Foundation.generate_links(page_list, paginator)
-  end
-  defp render_page_list(page_list, paginator, [theme: :semantic, path: _path, params: _params, opts: _opts]) do
-    Kerosene.HTML.Semantic.generate_links(page_list, paginator)
-  end
-  defp render_page_list(page_list, paginator, _opts) do
-    generate_links(page_list, paginator)
+  defp render_page_list(page_list, paginator, [theme: theme, path: _path, params: _params, opts: _opts]) do
+    case theme do
+      :bootstrap  -> Kerosene.HTML.Boostrap.generate_links(page_list, paginator)
+      :bootstrap4 -> Kerosene.HTML.Boostrap4.generate_links(page_list, paginator)
+      :foundation -> Kerosene.HTML.Foundation.generate_links(page_list, paginator)
+      :semantic   -> Kerosene.HTML.Semantic.generate_links(page_list, paginator)
+      _           -> generate_links(page_list, paginator)
+    end
   end
 
   defp generate_links(page_list, _paginator) do

--- a/lib/kerosene/html/bootstrap4.ex
+++ b/lib/kerosene/html/bootstrap4.ex
@@ -1,0 +1,23 @@
+defmodule Kerosene.HTML.Boostrap4 do
+  use Phoenix.HTML
+
+  def generate_links(page_list, paginator) do
+    content_tag :nav do
+      content_tag :ul, class: "pagination" do
+        for {label, page, path} <- page_list do
+          content_tag :li, class: build_html_class(paginator, page) do
+            link "#{label}", to: path, class: "page-link"
+          end
+        end
+      end
+    end
+  end
+
+  defp build_html_class(paginator, page) do
+    if paginator.page == page do
+      "page-item active"
+    else
+      "page-item "
+    end
+  end
+end


### PR DESCRIPTION
@allyraza It would be nice to have this merged in the nearest future :) I've decided to use this package, but it turned out it does not support Bootstrap 4. This PR fixes this issue :)

This is how it looks with `bootstrap4` theme and Bootstrap 4 css:
![image](https://cloud.githubusercontent.com/assets/883341/16501126/9b9d2934-3f10-11e6-8bbf-0ffd8c0f8d9b.png)

This is how pagination looks with default `bootstrap` theme and Boostrap 4 css.
![image](https://cloud.githubusercontent.com/assets/883341/16501198/e8750876-3f10-11e6-8576-23d76cfa7c79.png)
