### PR TITLE
Fix rendering pagination: first, previous, next, last

### DIFF
--- a/lib/kerosene/html.ex
+++ b/lib/kerosene/html.ex
@@ -1,7 +1,7 @@
 defmodule Kerosene.HTML do
   use Phoenix.HTML
 
-  @default [theme: :bootstrap, window: 5, next: "Next", previous: "Previous", first: true, last: true]
+  @default [theme: :bootstrap, window: 5, next_label: "Next", previous_label: "Previous", first: true, first_label: "First", last: true, last_label: "Last"]
   @themes [:bootstrap, :bootstrap4, :foundation, :semantic]
 
   @moduledoc """
@@ -19,7 +19,7 @@ defmodule Kerosene.HTML do
   Where `@page` is a `%Kerosene{}` struct returned from `Repo.paginate/2`.
 
   `paginate` helper takes keyword list of `options` and `params`.
-    <%= paginate @conn, @page, window: 5, next: ">>", previous: "<<", first: true, last: true %>
+    <%= paginate @conn, @page, window: 5, next_label: ">>", previous_label: "<<", first: true, last: true, first_label: "First", last_label: "Last" %>
   """
 
   @doc """
@@ -66,11 +66,22 @@ defmodule Kerosene.HTML do
 
     paginator.page
       |> previous_page
-      |> first_page(paginator.page, opts[:window], opts[:first])
+      |> first_page(paginator.page, opts[:window], opts[:opts][:first])
       |> page_list(paginator.page, paginator.total_pages, opts[:window])
-      |> last_page(paginator.page, paginator.total_pages, opts[:window], opts[:last])
       |> next_page(paginator.page, paginator.total_pages)
-      |> Enum.map(fn {label, page} -> {label, page, build_url(conn, Keyword.merge(paginator.params, [page: page]))} end)
+      |> last_page(paginator.page, paginator.total_pages, opts[:window], opts[:opts][:last])
+      |> Enum.map(fn {label, page} -> {label_text(label, opts), page, build_url(conn, Keyword.merge(paginator.params, [page: page]))} end)
+  end
+
+  defp label_text(label, opts) do
+    opts = opts[:opts]
+    case label do
+      :first    -> opts[:first_label]
+      :previous -> opts[:previous_label]
+      :next     -> opts[:next_label]
+      :last     -> opts[:last_label]
+      _         -> label
+    end
   end
 
   defp render_page_list(page_list, paginator, [theme: theme, path: _path, params: _params, opts: _opts]) do


### PR DESCRIPTION
@allyraza one more PR for you :)

**This PR fixes:**
 
- wrong order of last and previous links (now they have logical order)
![image](https://cloud.githubusercontent.com/assets/883341/16534954/4acc9e86-3fec-11e6-9ed3-e2158c574693.png)

- calls to `first_page/4` and `last_page/5` functions in `build_page_list/3`: those methods were passed wrong `opts` (default ones) instead of options, provided by the user (that were merged into `opts[:opts]`), so `last: false` did nothing and last page was still rendered (the same situation was with the first page).

- problem with rendering labels: pagination did not render labels, provided by the user, so if user provided `previous: "Go to previous page"`, still text `"previous"` was rendered (even not `"Previous"`, because function just took `:previous` atom and printed it like text instead of printing label text, provided by the user for this key)
![image](https://cloud.githubusercontent.com/assets/883341/16535049/06f84a24-3fed-11e6-8c61-d688dd0f38dd.png)

- printing label for `last` and `first` pages, that also always were printing atoms converted to strings (even without capitalisation, that gave no control over this labels and no possibility to translate them)

-  inconsistency in options names: now labels have `_label` suffix, so we have `:first_label`, `:previous_label`, `:next_label` and `:last_label`, so we can clearly differentiate between boolean `last: true` and `first: true`, so now users will not be confused

**This is fully customisable result of this PR:**
![image](https://cloud.githubusercontent.com/assets/883341/16535210/582c01a0-3fee-11e6-903c-466f0f2c45e5.png)
