### PR TITLE
Remove postgrex as a runtime dependency..

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## next
+* Don't require postgrex as a runtime dependency
+
 ## v0.4.0 (2016-10-01)
 * Bugfix handle list in query params
 

--- a/mix.exs
+++ b/mix.exs
@@ -41,7 +41,8 @@ defmodule Kerosene.Mixfile do
     [{:phoenix_html, "~> 2.7"},
      {:plug, "~> 1.0"},
      {:ecto, "~> 2.0"},
-     {:postgrex, "~> 0.11.0"},
+     # Test dependencies
+     {:postgrex, "~> 0.11.0", only: [:test]},
      # Docs dependencies
      {:earmark, "~> 0.1", only: :docs},
      {:ex_doc, "~> 0.11", only: :docs},


### PR DESCRIPTION
- Is only used for test setup - not referenced in code
- Making this change makes it so a mysql-using app (using mariaex)
  doesn't have to pull in postgrex when adding page numbers