### PR TITLE
Add total_count option to Kerosene.paginate

### DIFF
--- a/lib/kerosene.ex
+++ b/lib/kerosene.ex
@@ -22,7 +22,7 @@ defmodule Kerosene do
   def paginate(repo, query, opts) do
     per_page = get_per_page(opts)
     page = get_page(opts)
-    total_count = get_total_count(repo, query)
+    total_count = get_total_count(opts[:total_count], repo, query)
 
     kerosene = %Kerosene {
       per_page: per_page,
@@ -43,7 +43,8 @@ defmodule Kerosene do
     |> repo.all
   end
 
-  defp get_total_count(repo, query) do
+  defp get_total_count(count, _repo, _query) when is_integer(count) and count >= 0, do: count
+  defp get_total_count(_count, repo, query) do
     primary_key = get_primary_key(query)
 
     total_pages =
@@ -72,14 +73,14 @@ defmodule Kerosene do
   end
 
   def get_per_page(params) do
-    params 
-    |> Keyword.get(:per_page, 10) 
+    params
+    |> Keyword.get(:per_page, 10)
     |> to_integer
   end
 
   def get_page(params) do
-    params 
-    |> Keyword.get(:page, 1) 
+    params
+    |> Keyword.get(:page, 1)
     |> to_integer
   end
 

--- a/test/kerosene_test.exs
+++ b/test/kerosene_test.exs
@@ -23,13 +23,13 @@ defmodule KeroseneTest do
   test "have total pages based on per_page" do
     create_products()
     {_items, kerosene} = Product |> Repo.paginate(%{}, per_page: 5)
-    assert kerosene.total_pages == 2 
+    assert kerosene.total_pages == 2
   end
 
   test "uses default config" do
     create_products()
     {_items, kerosene} = Product |> Repo.paginate(%{})
-    assert kerosene.total_pages == 1 
+    assert kerosene.total_pages == 1
     assert kerosene.page == 1
   end
 
@@ -38,6 +38,20 @@ defmodule KeroseneTest do
     per_page = 10
     total_pages = 10
     assert Kerosene.get_total_pages(row_count, per_page) == total_pages
+  end
+
+  test "uses total_count provided via opts" do
+    create_products()
+    {_items, kerosene} = Product |> Repo.paginate(%{}, total_count: 3, per_page: 5)
+    assert kerosene.total_count == 3
+    assert kerosene.total_pages == 1
+  end
+
+  test "fallbacks to count query when provided total_count is nil" do
+    create_products()
+    {_items, kerosene} = Product |> Repo.paginate(%{}, total_count: nil, per_page: 5)
+    assert kerosene.total_count == 10
+    assert kerosene.total_pages == 2
   end
 
   test "return integer from binary" do


### PR DESCRIPTION
In cases when total_count has been cached or already known, it's beneficial to avoid making costly count query.