### PR TITLE
Avoid pagination when per_page is explicitly nil

### DIFF
--- a/lib/kerosene.ex
+++ b/lib/kerosene.ex
@@ -35,6 +35,7 @@ defmodule Kerosene do
     {get_items(repo, query, per_page, page), kerosene}
   end
 
+  defp get_items(repo, query, nil, _), do: repo.all(query)
   defp get_items(repo, query, per_page, page) do
     offset = per_page * (page - 1)
     query
@@ -68,14 +69,16 @@ defmodule Kerosene do
     |> hd
   end
 
+  def get_total_pages(_, nil), do: 1
   def get_total_pages(count, per_page) do
     Float.ceil(count / per_page) |> trunc
   end
 
   def get_per_page(params) do
-    params
-    |> Keyword.get(:per_page, 10)
-    |> to_integer
+    case Keyword.get(params, :per_page) do
+      nil       -> nil
+      per_page  -> per_page |> to_integer
+    end
   end
 
   def get_page(params) do

--- a/test/kerosene_test.exs
+++ b/test/kerosene_test.exs
@@ -8,7 +8,7 @@ defmodule KeroseneTest do
   end
 
   defp create_products do
-    for _ <- 1..10 do
+    for _ <- 1..15 do
       %Product { name: "Product 1", price: 100.00 }
       |> Repo.insert!
     end
@@ -20,17 +20,26 @@ defmodule KeroseneTest do
     assert kerosene.per_page == 5
   end
 
+  test "returns all the records" do
+    create_products()
+    {items, kerosene} = Product |> Repo.paginate(%{}, per_page: nil)
+    assert length(items) == 15
+    assert kerosene.total_pages == 1
+    assert kerosene.total_count == 15
+  end
+
   test "have total pages based on per_page" do
     create_products()
     {_items, kerosene} = Product |> Repo.paginate(%{}, per_page: 5)
-    assert kerosene.total_pages == 2
+    assert kerosene.total_pages == 3
   end
 
   test "uses default config" do
     create_products()
-    {_items, kerosene} = Product |> Repo.paginate(%{})
-    assert kerosene.total_pages == 1
+    {items, kerosene} = Product |> Repo.paginate(%{})
+    assert kerosene.total_pages == 2
     assert kerosene.page == 1
+    assert length(items) == 10
   end
 
   test "work out total pages" do
@@ -50,8 +59,8 @@ defmodule KeroseneTest do
   test "fallbacks to count query when provided total_count is nil" do
     create_products()
     {_items, kerosene} = Product |> Repo.paginate(%{}, total_count: nil, per_page: 5)
-    assert kerosene.total_count == 10
-    assert kerosene.total_pages == 2
+    assert kerosene.total_count == 15
+    assert kerosene.total_pages == 3
   end
 
   test "return integer from binary" do


### PR DESCRIPTION
This PR refers to the issue #23 to disable pagination. It might be useful when using Kerosene inside a set of *query functions* that use `Repo.paginate` by default but you want to disable it for specific use cases.

If you want to disable pagination, just pass an explicit `per_page: nil` option.