### PR TITLE
Fix total count query when group by clause is present

### DIFF
--- a/lib/kerosene.ex
+++ b/lib/kerosene.ex
@@ -47,15 +47,20 @@ defmodule Kerosene do
   defp get_total_count(_count, repo, query) do
     primary_key = get_primary_key(query)
 
-    total_pages =
+    total_count =
       query
       |> exclude(:preload)
       |> exclude(:order_by)
       |> exclude(:select)
+      |> consider_group_by()
       |> select([i], count(field(i, ^primary_key), :distinct))
       |> repo.one
-    total_pages || 0
+
+    total_count || 0
   end
+
+  defp consider_group_by(query = %{group_bys: []}), do: query
+  defp consider_group_by(query), do: from subquery(query)
 
   def get_primary_key(query) do
     new_query = case is_map(query) do

--- a/priv/repo/migrations/20170505194400_create_orders.exs
+++ b/priv/repo/migrations/20170505194400_create_orders.exs
@@ -1,0 +1,9 @@
+defmodule Kerosene.Repo.Migrations.CreateOrders do
+  use Ecto.Migration
+
+  def change do
+    create table(:orders) do
+      add :product_id, references(:products, on_delete: :nilify_all)
+    end
+  end
+end

--- a/test/support/order.ex
+++ b/test/support/order.ex
@@ -1,0 +1,7 @@
+defmodule Kerosene.Order do
+  use Ecto.Schema
+
+  schema "orders" do
+    belongs_to :product, Kerosene.Product
+  end
+end

--- a/test/support/product.ex
+++ b/test/support/product.ex
@@ -4,7 +4,9 @@ defmodule Kerosene.Product do
   schema "products" do
     field :name, :string
     field :price, :decimal
+    field :orders_count, :integer, virtual: :true
+    timestamps()
 
-    timestamps
+    has_many :orders, Kerosene.Order
   end
 end


### PR DESCRIPTION
For queries with group by clause total count query fails:
```
     ** (Ecto.MultipleResultsError) expected at most one result but got 10 in query:

     from p in Kerosene.Product,
       left_join: o in assoc(p, :orders),
       group_by: [p.id],
       select: count(p.id, :distinct)
```

This PR fixes it by wrapping such queries in a subquery.