### PR TITLE
added materialize support

### DIFF
--- a/lib/kerosene/html.ex
+++ b/lib/kerosene/html.ex
@@ -62,11 +62,12 @@ defmodule Kerosene.HTML do
 
   defp render_page_list(page_list, opts) do
     case opts[:theme] do
-      :bootstrap  -> HTML.Bootstrap.generate_links(page_list, opts[:class])
-      :bootstrap4 -> HTML.Bootstrap4.generate_links(page_list, opts[:class])
-      :foundation -> HTML.Foundation.generate_links(page_list, opts[:class])
-      :semantic   -> HTML.Semantic.generate_links(page_list, opts[:class])
-      _           -> HTML.Simple.generate_links(page_list, opts[:class])
+      :bootstrap   -> HTML.Bootstrap.generate_links(page_list, opts[:class])
+      :bootstrap4  -> HTML.Bootstrap4.generate_links(page_list, opts[:class])
+      :foundation  -> HTML.Foundation.generate_links(page_list, opts[:class])
+      :semantic    -> HTML.Semantic.generate_links(page_list, opts[:class])
+      :materialize -> HTML.Materialize.generate_links(page_list, opts[:class])
+      _            -> HTML.Simple.generate_links(page_list, opts[:class])
     end
   end
 end

--- a/lib/kerosene/html/materialize.ex
+++ b/lib/kerosene/html/materialize.ex
@@ -1,0 +1,19 @@
+defmodule Kerosene.HTML.Materialize do
+  use Phoenix.HTML
+
+  def generate_links(page_list, additional_class) do
+    content_tag :ul, class: build_html_class(additional_class) do
+    for {label, _page, url, current} <- page_list do
+        content_tag :li, class: build_html_class(current) do
+        link "#{label}", to: url
+        end
+    end
+    end
+  end
+
+  defp build_html_class(true), do: "active"
+  defp build_html_class(false), do: "waves-effect"
+  defp build_html_class(additional_class) do
+    String.trim("pagination #{additional_class}")
+  end
+end


### PR DESCRIPTION
I have added support for Materialize. I have to admit, it's not as it should be. Currently a pagination generated by kerosene looks something like:

`First Previous 1 2 3 4 Next Last `

While in Materialize it looks like:

`< 1 2 3 4 >`

Code example from http://materializecss.com/pagination.html#!

```
  <ul class="pagination">
    <li class="disabled"><a href="#!"><i class="material-icons">chevron_left</i></a></li>
    <li class="active"><a href="#!">1</a></li>
    <li class="waves-effect"><a href="#!">2</a></li>
    <li class="waves-effect"><a href="#!">3</a></li>
    <li class="waves-effect"><a href="#!">4</a></li>
    <li class="waves-effect"><a href="#!">5</a></li>
    <li class="waves-effect"><a href="#!"><i class="material-icons">chevron_right</i></a></li>
  </ul>
```

I did not immediately see how I can resolve this, but I'll gladly hear your feedback.

- m1dnight