### PR TITLE
Group by support

### DIFF
--- a/lib/kerosene.ex
+++ b/lib/kerosene.ex
@@ -65,21 +65,26 @@ defmodule Kerosene do
 
   defp get_total_count(count, _repo, _query) when is_integer(count) and count >= 0, do: count
 
-  defp get_total_count(_count, repo, query = %{group_bys: _}) do
-    primary_key = get_primary_key(query)
-
-    total_pages =
+  defp get_total_count(_count, repo, query = %{group_bys: [_|_]}) do
+    total_pages = 
       query
-      |> exclude(:preload)
-      |> exclude(:order_by)
-      |> exclude(:select)
-      |> select([i], count(field(i, ^primary_key), :distinct))
+      |> total_count_query()
       |> repo.all()
       |> Enum.count()
+
     total_pages || 0
   end
 
   defp get_total_count(_count, repo, query) do
+    total_pages = 
+      query
+      |> total_count_query()
+      |> repo.one
+
+    total_pages || 0
+  end
+
+  defp total_count_query(query) do
     primary_key = get_primary_key(query)
 
     total_pages =
@@ -88,8 +93,6 @@ defmodule Kerosene do
       |> exclude(:order_by)
       |> exclude(:select)
       |> select([i], count(field(i, ^primary_key), :distinct))
-      |> repo.one
-    total_pages || 0
   end
 
   def get_primary_key(query) do

--- a/lib/kerosene.ex
+++ b/lib/kerosene.ex
@@ -64,6 +64,21 @@ defmodule Kerosene do
   end
 
   defp get_total_count(count, _repo, _query) when is_integer(count) and count >= 0, do: count
+
+  defp get_total_count(_count, repo, query = %{group_bys: _}) do
+    primary_key = get_primary_key(query)
+
+    total_pages =
+      query
+      |> exclude(:preload)
+      |> exclude(:order_by)
+      |> exclude(:select)
+      |> select([i], count(field(i, ^primary_key), :distinct))
+      |> repo.all()
+      |> Enum.count()
+    total_pages || 0
+  end
+
   defp get_total_count(_count, repo, query) do
     primary_key = get_primary_key(query)
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,7 @@
-%{"connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [:mix], []},
-  "db_connection": {:hex, :db_connection, "1.0.0", "63c03e520d54886a66104d34e32397ba960db6e74b596ce221592c07d6a40d8d", [:mix], [{:connection, "~> 1.0.2", [hex: :connection, optional: false]}, {:poolboy, "~> 1.5", [hex: :poolboy, optional: true]}, {:sbroker, "~> 1.0", [hex: :sbroker, optional: true]}]},
-  "decimal": {:hex, :decimal, "1.2.0", "462960fd71af282e570f7b477f6be56bf8968e68277d4d0b641a635269bf4b0d", [:mix], []},
+%{
+  "connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [:mix], []},
+  "db_connection": {:hex, :db_connection, "1.1.3", "89b30ca1ef0a3b469b1c779579590688561d586694a3ce8792985d4d7e575a61", [:mix], [{:connection, "~> 1.0.2", [hex: :connection, repo: "hexpm", optional: false]}, {:poolboy, "~> 1.5", [hex: :poolboy, repo: "hexpm", optional: true]}, {:sbroker, "~> 1.0", [hex: :sbroker, repo: "hexpm", optional: true]}], "hexpm"},
+  "decimal": {:hex, :decimal, "1.4.1", "ad9e501edf7322f122f7fc151cce7c2a0c9ada96f2b0155b8a09a795c2029770", [:mix], [], "hexpm"},
   "earmark": {:hex, :earmark, "0.2.1", "ba6d26ceb16106d069b289df66751734802777a3cbb6787026dd800ffeb850f3", [:mix], []},
   "ecto": {:hex, :ecto, "2.0.5", "7f4c79ac41ffba1a4c032b69d7045489f0069c256de606523c65d9f8188e502d", [:mix], [{:db_connection, "~> 1.0-rc.4", [hex: :db_connection, optional: true]}, {:decimal, "~> 1.1.2 or ~> 1.2", [hex: :decimal, optional: false]}, {:mariaex, "~> 0.7.7", [hex: :mariaex, optional: true]}, {:poison, "~> 1.5 or ~> 2.0", [hex: :poison, optional: true]}, {:poolboy, "~> 1.5", [hex: :poolboy, optional: false]}, {:postgrex, "~> 0.12.0", [hex: :postgrex, optional: true]}, {:sbroker, "~> 1.0-beta", [hex: :sbroker, optional: true]}]},
   "ex_doc": {:hex, :ex_doc, "0.12.0", "b774aabfede4af31c0301aece12371cbd25995a21bb3d71d66f5c2fe074c603f", [:mix], [{:earmark, "~> 0.2", [hex: :earmark, optional: false]}]},
@@ -10,4 +11,5 @@
   "plug": {:hex, :plug, "1.2.2", "cfbda521b54c92ab8ddffb173fbaabed8d8fc94bec07cd9bb58a84c1c501b0bd", [:mix], [{:cowboy, "~> 1.0", [hex: :cowboy, optional: true]}, {:mime, "~> 1.0", [hex: :mime, optional: false]}]},
   "poison": {:hex, :poison, "2.2.0", "4763b69a8a77bd77d26f477d196428b741261a761257ff1cf92753a0d4d24a63", [:mix], []},
   "poolboy": {:hex, :poolboy, "1.5.1", "6b46163901cfd0a1b43d692657ed9d7e599853b3b21b95ae5ae0a777cf9b6ca8", [:rebar], []},
-  "postgrex": {:hex, :postgrex, "0.12.1", "2f8b46cb3a44dcd42f42938abedbfffe7e103ba4ce810ccbeee8dcf27ca0fb06", [:mix], [{:connection, "~> 1.0", [hex: :connection, optional: false]}, {:db_connection, "~> 1.0-rc.4", [hex: :db_connection, optional: false]}, {:decimal, "~> 1.0", [hex: :decimal, optional: false]}]}}
+  "postgrex": {:hex, :postgrex, "0.12.2", "13cfd784a148da78f0edddd433bcef5c98388fdb2963ba25ed1fa7265885e6bf", [:mix], [{:connection, "~> 1.0", [hex: :connection, repo: "hexpm", optional: false]}, {:db_connection, "~> 1.0", [hex: :db_connection, repo: "hexpm", optional: false]}, {:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: false]}], "hexpm"},
+}

--- a/test/kerosene_test.exs
+++ b/test/kerosene_test.exs
@@ -2,6 +2,7 @@ defmodule KeroseneTest do
   use ExUnit.Case
   alias Kerosene.Repo
   alias Kerosene.Product
+  import Ecto.Query
 
   setup do
     :ok = Ecto.Adapters.SQL.Sandbox.checkout(Kerosene.Repo)
@@ -12,6 +13,13 @@ defmodule KeroseneTest do
       %Product { name: "Product 1", price: 100.00 }
       |> Repo.insert!
     end
+  end
+
+  test "group_by" do
+    create_products()
+    Product
+    |> group_by([p], p.id)
+    |> Repo.paginate(%{})
   end
 
   test "per_page option" do

--- a/test/kerosene_test.exs
+++ b/test/kerosene_test.exs
@@ -15,11 +15,10 @@ defmodule KeroseneTest do
     end
   end
 
-  test "group_by" do
+  test "group_by in query" do
     create_products()
-    Product
-    |> group_by([p], p.id)
-    |> Repo.paginate(%{})
+    {_items, kerosene} = Product |> group_by([p], p.id) |> Repo.paginate(%{})
+    assert kerosene.total_count == 15
   end
 
   test "per_page option" do


### PR DESCRIPTION
Previously if you had a query with a group_by with more than 1 row in the results you would get an error:
"(Ecto.MultipleResultsError) expected at most one result but got x in query"
I've updated the code to support group by queries by using a count and subquery
I've added a test to keronsene_test.ex to replicate the issue which now passes
