### PR TITLE
Fix warning when running tests in Elixir 1.7

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -64,6 +64,6 @@ defmodule Kerosene.Mixfile do
   end
 
   def aliases do
-    ["test": ["ecto.create --quite", "ecto.migrate --quite", "test"]]
+    [test: ["ecto.create --quite", "ecto.migrate --quite", "test"]]
   end
 end


### PR DESCRIPTION
Warning appears every time when running `mix test` in a project with kerosene as a dependency.