### PR TITLE
Add limit to row_count function

### DIFF
--- a/lib/kerosene.ex
+++ b/lib/kerosene.ex
@@ -84,12 +84,14 @@ defmodule Kerosene do
     query
     |> exclude(:select)
     |> select([i], count(field(i, ^primary_key), :distinct))
+    |> limit(1)
   end
 
   defp total_row_count(query) do
     query
     |> subquery()
     |> select(count("*"))
+    |> limit(1)
   end
 
   def get_primary_key(query) do


### PR DESCRIPTION
I have a query that took ~ 6 seconds to resolve because of the time it takes for the library to resolve the following line of code. 

Since we are only expecting 1 row of result, I noticed adding limit(1) brings the result time 652ms instead.

```elixir
defp total_count(query = %{group_bys: [_|_]}), do: total_row_count(query)
  defp total_count(query = %{from: %{source: {_, nil}}}), do: total_row_count(query)

  defp total_count(query) do
    primary_key = get_primary_key(query)
    query
    |> exclude(:select)
    |> select([i], count(field(i, ^primary_key), :distinct))
+    |> limit(1)
  end

  defp total_row_count(query) do
    query
    |> subquery()
    |> select(count("*"))
+    |> limit(1)
  end
```